### PR TITLE
Fix Initial Commit Get Diff

### DIFF
--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -8,21 +8,13 @@ jobs:
   nightfalldlp:
     name: nightfalldlp
     runs-on: ubuntu-latest
-    env:
-      ACTION_VERSION: nightfallai/nightfall_dp_action@${{ github.head_ref }}
     steps:
       - name: Checkout Repo Action
         uses: actions/checkout@v2
 
-      - name: Echo Action Version
-        run: echo $ACTION_ECHO
-        env:
-          ACTION_ECHO: ${{env.ACTION_VERSION}}
-
       - name: nightfallDLP action step
-        uses: $ACTION_V
+        uses: nightfallai/nightfall_dlp_action@FixInitialCommitDiff
         env:
-          ACTION_V: ${{env.ACTION_VERSION}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}
           EVENT_BEFORE: ${{ github.event.before }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -19,10 +19,10 @@ jobs:
         env:
           ACTION_V: ${{env.ACTION_VERSION}}
 
-
-      #- name: nightfallDLP action step
-      #  uses: ${{ ACTION_VERSION }}
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #    NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}
-      #    EVENT_BEFORE: ${{ github.event.before }}
+      - name: nightfallDLP action step
+        uses: ${{ env.ACTION_V }}
+        env:
+          ACTION_V: ${{env.ACTION_VERSION}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}
+          EVENT_BEFORE: ${{ github.event.before }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -12,12 +12,18 @@ jobs:
       - name: Checkout Repo Action
         uses: actions/checkout@v2
 
+      - name: Echo Github Ref
+        run: echo $GITHUB_REF
+
       - name: Set Action Ref
         run: echo "::set-env name=action_ref::$GITHUB_REF"
 
-      - name: nightfallDLP action step
-        uses: nightfallai/nightfall_dlp_action@${{ env.action_ref }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}
-          EVENT_BEFORE: ${{ github.event.before }}
+      #- name: nightfallDLP action step
+      #  uses: nightfallai/nightfall_dlp_action@${{ env.action_ref }}
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #    NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}
+      #    EVENT_BEFORE: ${{ github.event.before }}
+
+      - name: Echo Env Var
+        run: echo ${{ env.action_ref}}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -16,7 +16,7 @@ jobs:
         run: echo $GITHUB_HEAD_REF
 
       - name: nightfallDLP action step
-        uses: nightfallai/nightfall_dlp_action@${{ GITHUB_HEAD_REF }}
+        uses: nightfallai/nightfall_dlp_action@${{ github.head_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -15,11 +15,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Echo Action Version
-        run: echo ${{ ACTION_VERSION }}
-
-      - name: nightfallDLP action step
-        uses: ${{ ACTION_VERSION }}
+        run: echo $ACTION_V
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}
-          EVENT_BEFORE: ${{ github.event.before }}
+          ACTION_V: ${{env.ACTION_VERSION}}
+
+
+      #- name: nightfallDLP action step
+      #  uses: ${{ ACTION_VERSION }}
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #    NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}
+      #    EVENT_BEFORE: ${{ github.event.before }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -13,10 +13,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Echo Head Ref
-        run: echo $GITHUB_HEAD_REF
+        run: echo ::set-env name=action_version::nightfallai/nightfall_dp_action@$GITHUB_HEAD_REF
 
       - name: nightfallDLP action step
-        uses: nightfallai/nightfall_dlp_action@${{ github.head_ref }}
+        uses: ${{ env.action_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -16,7 +16,7 @@ jobs:
         run: echo $GITHUB_HEAD_REF
 
       - name: nightfallDLP action step
-        uses: nightfallai/nightfall_dlp_action@$GITHUB_HEAD_REF
+        uses: nightfallai/nightfall_dlp_action@${{ GITHUB_HEAD_REF }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -15,12 +15,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Echo Action Version
-        run: echo $ACTION_V
+        run: echo $ACTION_ECHO
         env:
-          ACTION_V: ${{env.ACTION_VERSION}}
+          ACTION_ECHO: ${{env.ACTION_VERSION}}
 
       - name: nightfallDLP action step
-        uses: ${{ env.ACTION_V }}
+        uses: $ACTION_V
         env:
           ACTION_V: ${{env.ACTION_VERSION}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: nightfallDLP action step
-        uses: nightfallai/nightfall_dlp_action@${{ github.event.ref }}
+        uses: nightfallai/nightfall_dlp_action
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: nightfallDLP action step
-        uses: nightfallai/nightfall_dlp_action@FixInitialCommitDiff
+        uses: nightfallai/nightfall_dlp_action@${{ github.event.ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -12,9 +12,21 @@ jobs:
       - name: Checkout Repo Action
         uses: actions/checkout@v2
 
+      - name: Echo SHA
+        run: echo ${{ github.sha }}
+
+      - name: Echo base_ref
+        run: echo ${{ github.base_ref }}
+
+      - name: Echo event before
+        run: echo ${{ github.event.before }}
+
       - name: nightfallDLP action step
         uses: nightfallai/nightfall_dlp_action@FixInitialCommitDiff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}
           EVENT_BEFORE: ${{ github.event.before }}
+
+      - name: Echo Diff
+        run: cat "./nightfalldlp_raw_diff.txt"

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -12,6 +12,9 @@ jobs:
       - name: Checkout Repo Action
         uses: actions/checkout@v2
 
+      - name: Echo Head Ref
+        run: echo $GITHUB_HEAD_REF
+
       - name: nightfallDLP action step
         uses: nightfallai/nightfall_dlp_action@FixInitialCommitDiff
         env:

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Echo SHA
         run: echo ${{ github.sha }}
 
+      - name: Echo PR Head SHA
+        run: echo ${{ github.event.pull_request.head.sha }}
+
       - name: Echo base_ref
         run: echo ${{ github.base_ref }}
 

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -16,7 +16,7 @@ jobs:
         run: echo $GITHUB_HEAD_REF
 
       - name: nightfallDLP action step
-        uses: nightfallai/nightfall_dlp_action@FixInitialCommitDiff
+        uses: nightfallai/nightfall_dlp_action@$GITHUB_HEAD_REF
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: nightfallDLP action step
-        uses: nightfallai/nightfall_dlp_action@v0.0.2
+        uses: nightfallai/nightfall_dlp_action@FixInitialCommitDiff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -12,11 +12,8 @@ jobs:
       - name: Checkout Repo Action
         uses: actions/checkout@v2
 
-      - name: Echo Github Ref
-        run: echo $GITHUB_REF
-
       - name: nightfallDLP action step
-        uses: "nightfallai/nightfall_dlp_action@$GITHUB_REF"
+        uses: nightfallai/nightfall_dlp_action@FixInitialCommitDiff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -12,24 +12,9 @@ jobs:
       - name: Checkout Repo Action
         uses: actions/checkout@v2
 
-      - name: Echo SHA
-        run: echo ${{ github.sha }}
-
-      - name: Echo PR Head SHA
-        run: echo ${{ github.event.pull_request.head.sha }}
-
-      - name: Echo base_ref
-        run: echo ${{ github.base_ref }}
-
-      - name: Echo event before
-        run: echo ${{ github.event.before }}
-
       - name: nightfallDLP action step
         uses: nightfallai/nightfall_dlp_action@FixInitialCommitDiff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}
           EVENT_BEFORE: ${{ github.event.before }}
-
-      - name: Echo Diff
-        run: cat "./nightfalldlp_raw_diff.txt"

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
 jobs:
   nightfalldlp:
+    env:
+      action_version: nightfallai/nightfall_dlp_action/${{ github.event.ref }}
     name: nightfalldlp
     runs-on: ubuntu-latest
     steps:
@@ -13,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: nightfallDLP action step
-        uses: nightfallai/nightfall_dlp_action
+        uses: ${{ env.action_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: nightfallDLP action step
-        uses: ${{ env.action_version }}
+        uses: ${{ action_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -15,15 +15,9 @@ jobs:
       - name: Echo Github Ref
         run: echo $GITHUB_REF
 
-      - name: Set Action Ref
-        run: echo "::set-env name=action_ref::$GITHUB_REF"
-
-      #- name: nightfallDLP action step
-      #  uses: nightfallai/nightfall_dlp_action@${{ env.action_ref }}
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #    NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}
-      #    EVENT_BEFORE: ${{ github.event.before }}
-
-      - name: Echo Env Var
-        run: echo ${{ env.action_ref}}
+      - name: nightfallDLP action step
+        uses: "nightfallai/nightfall_dlp_action@$GITHUB_REF"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}
+          EVENT_BEFORE: ${{ github.event.before }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -6,16 +6,17 @@ on:
   pull_request:
 jobs:
   nightfalldlp:
-    env:
-      action_version: nightfallai/nightfall_dlp_action/${{ github.event.ref }}
     name: nightfalldlp
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo Action
         uses: actions/checkout@v2
 
+      - name: Set Action Ref
+        run: echo "::set-env name=action_ref::$GITHUB_REF"
+
       - name: nightfallDLP action step
-        uses: ${{ action_version }}
+        uses: nightfallai/nightfall_dlp_action@${{ env.action_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -8,15 +8,17 @@ jobs:
   nightfalldlp:
     name: nightfalldlp
     runs-on: ubuntu-latest
+    env:
+      ACTION_VERSION: nightfallai/nightfall_dp_action@${{ github.head_ref }}
     steps:
       - name: Checkout Repo Action
         uses: actions/checkout@v2
 
-      - name: Echo Head Ref
-        run: echo ::set-env name=action_version::nightfallai/nightfall_dp_action@$GITHUB_HEAD_REF
+      - name: Echo Action Version
+        run: echo ${{ ACTION_VERSION }}
 
       - name: nightfallDLP action step
-        uses: ${{ env.action_version }}
+        uses: ${{ ACTION_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTFALL_API_KEY: ${{ secrets.NIGHTFALL_API_KEY }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,9 +2,6 @@
 
 # download relevant branch and write the diff to a local file
 diff_filename="./nightfalldlp_raw_diff.txt"
-echo "GITHUB_SHA: $GITHUB_SHA";
-echo "BASE_REF: $GITHUB_BASE_REF";
-echo "EVENT_BEFORE: $EVENT_BEFORE";
 if [ "$GITHUB_BASE_REF" ]; then
   git fetch origin "$GITHUB_BASE_REF" --depth=1;
   echo "PR: fetching diff between origin/$GITHUB_BASE_REF and $GITHUB_SHA";
@@ -12,7 +9,6 @@ if [ "$GITHUB_BASE_REF" ]; then
 else
   if [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
     echo "PUSH: fetching diff of initial commit";
-    echo git show --format="" "$GITHUB_SHA"
     git show --format="" "$GITHUB_SHA" > $diff_filename;
   else
     git fetch origin "$EVENT_BEFORE" --depth=1;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ if [ "$GITHUB_BASE_REF" ]; then
 else
   if [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
     echo "PUSH: fetching diff between HEAD and $GITHUB_SHA";
+    git fetch origin HEAD --depth=1;
     git diff "HEAD" "$GITHUB_SHA" > $diff_filename;
   else
     git fetch origin "$EVENT_BEFORE" --depth=1;
@@ -22,4 +23,3 @@ fi;
 
 # run nightfalldlp binary
 "$GOPATH/bin/nightfalldlp"
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,9 +10,12 @@ if [ "$GITHUB_BASE_REF" ]; then
   echo "PR: fetching diff between origin/$GITHUB_BASE_REF and $GITHUB_SHA";
   git diff origin/"$GITHUB_BASE_REF" "$GITHUB_SHA" > $diff_filename;
 else
-  git fetch origin "$EVENT_BEFORE" --depth=1;
-  echo "PUSH: fetching diff between $EVENT_BEFORE and $GITHUB_SHA";
-  git diff "$EVENT_BEFORE" "$GITHUB_SHA" > $diff_filename;
+  if [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
+    git diff "HEAD" "$GITHUB_SHA" > $diff_filename;
+  else
+    git fetch origin "$EVENT_BEFORE" --depth=1;
+    echo "PUSH: fetching diff between $EVENT_BEFORE and $GITHUB_SHA";
+    git diff "$EVENT_BEFORE" "$GITHUB_SHA" > $diff_filename;
 fi;
 
 # run nightfalldlp binary

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ if [ "$GITHUB_BASE_REF" ]; then
   git diff origin/"$GITHUB_BASE_REF" "$GITHUB_SHA" > $diff_filename;
 else
   if [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
+    echo "PUSH: fetching diff between HEAD and $GITHUB_SHA";
     git diff "HEAD" "$GITHUB_SHA" > $diff_filename;
   else
     git fetch origin "$EVENT_BEFORE" --depth=1;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,9 +2,6 @@
 
 # download relevant branch and write the diff to a local file
 diff_filename="./nightfalldlp_raw_diff.txt"
-echo "GITHUB_SHA: $GITHUB_SHA";
-echo "BASE_REF: $GITHUB_BASE_REF";
-echo "EVENT_BEFORE: $EVENT_BEFORE";
 if [ "$GITHUB_BASE_REF" ]; then
   git fetch origin "$GITHUB_BASE_REF" --depth=1;
   echo "PR: fetching diff between origin/$GITHUB_BASE_REF and $GITHUB_SHA";

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,8 @@ if [ "$GITHUB_BASE_REF" ]; then
 else
   if [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
     echo "PUSH: fetching diff of initial commit";
-    echo git show "$GITHUB_SHA"
-    git show "$GITHUB_SHA" > $diff_filename;
+    echo git show --format="" "$GITHUB_SHA"
+    git show --format="" "$GITHUB_SHA" > $diff_filename;
   else
     git fetch origin "$EVENT_BEFORE" --depth=1;
     echo "PUSH: fetching diff between $EVENT_BEFORE and $GITHUB_SHA";

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,9 @@
 
 # download relevant branch and write the diff to a local file
 diff_filename="./nightfalldlp_raw_diff.txt"
+echo "GITHUB_SHA: $GITHUB_SHA";
+echo "BASE_REF: $GITHUB_BASE_REF";
+echo "EVENT_BEFORE: $EVENT_BEFORE";
 if [ "$GITHUB_BASE_REF" ]; then
   git fetch origin "$GITHUB_BASE_REF" --depth=1;
   echo "PR: fetching diff between origin/$GITHUB_BASE_REF and $GITHUB_SHA";

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,14 +11,9 @@ if [ "$GITHUB_BASE_REF" ]; then
   git diff origin/"$GITHUB_BASE_REF" "$GITHUB_SHA" > $diff_filename;
 else
   if [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
-    echo "PUSH: fetching diff between HEAD and $GITHUB_SHA";
-    git fetch origin HEAD;
-    echo "Echoing diff 1: "
-    echo git diff HEAD "$GITHUB_SHA"
-    # git diff HEAD "$GITHUB_SHA" > $diff_filename;
-    git fetch origin master;
-    echo "Echoing diff 2: "
-    echo git diff master;
+    echo "PUSH: fetching diff of initial commit";
+    echo git show "$GITHUB_SHA"
+    git show "$GITHUB_SHA" > $diff_filename;
   else
     git fetch origin "$EVENT_BEFORE" --depth=1;
     echo "PUSH: fetching diff between $EVENT_BEFORE and $GITHUB_SHA";

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,7 @@ else
     git fetch origin "$EVENT_BEFORE" --depth=1;
     echo "PUSH: fetching diff between $EVENT_BEFORE and $GITHUB_SHA";
     git diff "$EVENT_BEFORE" "$GITHUB_SHA" > $diff_filename;
+  fi;
 fi;
 
 # run nightfalldlp binary

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,13 @@ if [ "$GITHUB_BASE_REF" ]; then
 else
   if [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
     echo "PUSH: fetching diff between HEAD and $GITHUB_SHA";
-    git fetch origin HEAD --depth=1;
-    git diff "HEAD" "$GITHUB_SHA" > $diff_filename;
+    git fetch origin HEAD;
+    echo "Echoing diff 1: "
+    echo git diff HEAD "$GITHUB_SHA"
+    # git diff HEAD "$GITHUB_SHA" > $diff_filename;
+    git fetch origin master;
+    echo "Echoing diff 2: "
+    echo git diff master;
   else
     git fetch origin "$EVENT_BEFORE" --depth=1;
     echo "PUSH: fetching diff between $EVENT_BEFORE and $GITHUB_SHA";


### PR DESCRIPTION
This resolves the issue of not being able to get the diff of the first commit to a new repository.

Example of error: https://github.com/bradleymcallister97/Testing/runs/933049205?check_suite_focus=true
In the nightfallDLP action step, we get the following error:
```
fatal: expected shallow/unshallow, got ERR upload-pack: not our ref 0000000000000000000000000000000000000000
fatal: The remote end hung up unexpectedly
PUSH: fetching diff between 0000000000000000000000000000000000000000 and a64ba485a27ec122f9cc55f92506119669f9bd91
fatal: bad object 0000000000000000000000000000000000000000
```

Here is a working example of our check running on the initial commit (with one finding):
https://github.com/alan20854/NewRepo/runs/933751858